### PR TITLE
feat:(omkar_fieldapi):Add Custom RGB Color Field (Color RGB) via Field API

### DIFF
--- a/drupal/web/modules/custom/omkar_fieldapi/omkar_fieldapi.info.yml
+++ b/drupal/web/modules/custom/omkar_fieldapi/omkar_fieldapi.info.yml
@@ -1,0 +1,7 @@
+name: 'Omkar Field api'
+type: module
+description: 'Custom RGB color field using Field API..'
+core_version_requirement: ^11
+package: Custom
+dependencies:
+  - field

--- a/drupal/web/modules/custom/omkar_fieldapi/src/Plugin/Field/FieldFormatter/ColorFieldFormatter.php
+++ b/drupal/web/modules/custom/omkar_fieldapi/src/Plugin/Field/FieldFormatter/ColorFieldFormatter.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\omkar_fieldapi\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ *
+ */
+#[FieldFormatter(
+  id: "color_rgb_formatter",
+  label: new TranslatableMarkup("Color RGB Formatter"),
+  field_types: ["color_rgb"]
+)]
+class ColorFieldFormatter extends FormatterBase {
+
+  /**
+   *
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode): array {
+    $elements = [];
+
+    foreach ($items as $delta => $item) {
+      $color = sprintf("#%02x%02x%02x", $item->red, $item->green, $item->blue);
+
+      // Return the color value as plain markup or use a custom render array.
+      $elements[$delta] = [
+        '#markup' => $color,
+      ];
+    }
+
+    return $elements;
+  }
+
+}

--- a/drupal/web/modules/custom/omkar_fieldapi/src/Plugin/Field/FieldType/ColorFieldItem.php
+++ b/drupal/web/modules/custom/omkar_fieldapi/src/Plugin/Field/FieldType/ColorFieldItem.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\omkar_fieldapi\Plugin\Field\FieldType;
+
+use Drupal\Core\Field\FieldItemBase;
+use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\TypedData\DataDefinition;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ *
+ */
+#[FieldType(
+  id: "color_rgb",
+  label: new TranslatableMarkup("Color RGB"),
+  description: new TranslatableMarkup("Stores a color in RGB format."),
+  default_widget: "color_rgb_widget",
+  default_formatter: "color_rgb_formatter"
+)]
+class ColorFieldItem extends FieldItemBase {
+
+  /**
+   *
+   */
+  public static function propertyDefinitions(FieldStorageDefinitionInterface $field_definition): array {
+    $properties['red'] = DataDefinition::create('integer')->setLabel(new TranslatableMarkup('Red value'));
+    $properties['green'] = DataDefinition::create('integer')->setLabel(new TranslatableMarkup('Green value'));
+    $properties['blue'] = DataDefinition::create('integer')->setLabel(new TranslatableMarkup('Blue value'));
+    return $properties;
+  }
+
+  /**
+   *
+   */
+  public static function schema(FieldStorageDefinitionInterface $field_definition): array {
+    return [
+      'columns' => [
+        'red' => ['type' => 'int', 'size' => 'tiny', 'unsigned' => TRUE],
+        'green' => ['type' => 'int', 'size' => 'tiny', 'unsigned' => TRUE],
+        'blue' => ['type' => 'int', 'size' => 'tiny', 'unsigned' => TRUE],
+      ],
+    ];
+  }
+
+  /**
+   *
+   */
+  public function isEmpty(): bool {
+    return $this->get('red')->getValue() === NULL &&
+           $this->get('green')->getValue() === NULL &&
+           $this->get('blue')->getValue() === NULL;
+  }
+
+}

--- a/drupal/web/modules/custom/omkar_fieldapi/src/Plugin/Field/FieldWidget/ColorFieldWidget.php
+++ b/drupal/web/modules/custom/omkar_fieldapi/src/Plugin/Field/FieldWidget/ColorFieldWidget.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\omkar_fieldapi\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+#[FieldWidget(
+  id: "color_rgb_widget",
+  label: new TranslatableMarkup("Color RGB Widget"),
+  field_types: ["color_rgb"]
+)]
+class ColorFieldWidget extends WidgetBase {
+
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state): array {
+    $element['red'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Red'),
+      '#default_value' => $items[$delta]->red ?? 0,
+      '#min' => 0,
+      '#max' => 255,
+    ];
+    $element['green'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Green'),
+      '#default_value' => $items[$delta]->green ?? 0,
+      '#min' => 0,
+      '#max' => 255,
+    ];
+    $element['blue'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Blue'),
+      '#default_value' => $items[$delta]->blue ?? 0,
+      '#min' => 0,
+      '#max' => 255,
+    ];
+    return $element;
+  }
+
+}


### PR DESCRIPTION
Pull Request: Add Custom RGB Color Field (Color RGB) via Field API
Description: This PR introduces a custom Color RGB field type using Drupal’s Field API. It includes full support for storage, widget input, and frontend formatter display.

✨ Key Features:
✅ New Field Type: color_rgb (stores RGB values separately: red, green, blue).

✅ Custom Widget: Color RGB Widget – numeric input fields (0–255) for red, green, and blue.

✅ Custom Formatter: Color RGB Formatter – outputs color value as a hex code.

🔧 Fully configurable and usable in content types (e.g., Blog).

📦 Packaged under omkar_fieldapi custom module.

📁 Files Added:
ColorFieldItem.php – Field Type definition.

ColorFieldWidget.php – Input Widget.

ColorFieldFormatter.php – Display Formatter.

omkar_fieldapi.info.yml – Module definition.