### PR TITLE
feat:(omkar_cache_api):explored cache api to fetch latest blogs added…

### DIFF
--- a/drupal/web/modules/custom/omkar_cache_api/omkar_cache_api.info.yml
+++ b/drupal/web/modules/custom/omkar_cache_api/omkar_cache_api.info.yml
@@ -1,0 +1,7 @@
+name: 'Omkar Cache API'
+type: module
+description: 'Caches the latest blog posts to improve performance.'
+core_version_requirement: ^11
+package: Custom
+dependencies:
+  - drupal:node

--- a/drupal/web/modules/custom/omkar_cache_api/omkar_cache_api.module
+++ b/drupal/web/modules/custom/omkar_cache_api/omkar_cache_api.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Omkar Cache API module.
+ */

--- a/drupal/web/modules/custom/omkar_cache_api/omkar_cache_api.routing.yml
+++ b/drupal/web/modules/custom/omkar_cache_api/omkar_cache_api.routing.yml
@@ -1,0 +1,7 @@
+omkar_cache_api.latest_blogs:
+  path: '/latest-blogs'
+  defaults:
+    _controller: '\Drupal\omkar_cache_api\Controller\BlogController::latestBlogs'
+    _title: 'Latest Blog Posts'
+  requirements:
+    _permission: 'access content'

--- a/drupal/web/modules/custom/omkar_cache_api/omkar_cache_api.services.yml
+++ b/drupal/web/modules/custom/omkar_cache_api/omkar_cache_api.services.yml
@@ -1,0 +1,10 @@
+services:
+  omkar_cache_api.blog_cache_service:
+    class: 'Drupal\omkar_cache_api\Service\BlogCacheService'
+    arguments: ['@cache.default']
+
+  omkar_cache_api.blog_event_subscriber:
+    class: 'Drupal\omkar_cache_api\EventSubscriber\BlogEventSubscriber'
+    arguments: ['@omkar_cache_api.blog_cache_service']
+    tags:
+      - { name: event_subscriber }

--- a/drupal/web/modules/custom/omkar_cache_api/src/Controller/BlogController.php
+++ b/drupal/web/modules/custom/omkar_cache_api/src/Controller/BlogController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\omkar_cache_api\Controller;
+
+use Drupal\Core\Url;
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\omkar_cache_api\Service\BlogCacheService;
+
+/**
+ * Controller to display latest cached blog posts.
+ */
+class BlogController extends ControllerBase {
+
+  /**
+   *
+   */
+  protected $blogCacheService;
+
+  public function __construct(BlogCacheService $blogCacheService) {
+    $this->blogCacheService = $blogCacheService;
+  }
+
+  /**
+   *
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('omkar_cache_api.blog_cache_service')
+    );
+  }
+
+  /**
+   * Returns the latest blog posts.
+   */
+  public function latestBlogs() {
+    $blogs = $this->blogCacheService->getLatestBlogs();
+
+    // Debugging: Check if $blogs contains data.
+    \Drupal::logger('omkar_cache_api')->notice('<pre>' . print_r($blogs, TRUE) . '</pre>');
+
+    if (empty($blogs)) {
+      return [
+        '#markup' => '<p>No blogs available.</p>',
+      ];
+    }
+
+    $items = [];
+    foreach ($blogs as $blog) {
+      $items[] = [
+        '#type' => 'link',
+        '#title' => $blog['title'],
+        '#url' => Url::fromUserInput($blog['url']),
+      ];
+    }
+
+    return [
+      '#theme' => 'item_list',
+      '#items' => $items,
+      '#cache' => [
+        'tags' => ['node_list'],
+      ],
+    ];
+  }
+
+}

--- a/drupal/web/modules/custom/omkar_cache_api/src/EventSubscriber/BlogEventSubscriber.php
+++ b/drupal/web/modules/custom/omkar_cache_api/src/EventSubscriber/BlogEventSubscriber.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\omkar_cache_api\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\node\Event\NodeEvent;
+use Drupal\omkar_cache_api\Service\BlogCacheService;
+
+/**
+ * Event Subscriber to clear cache when a blog post is created or updated.
+ */
+class BlogEventSubscriber implements EventSubscriberInterface {
+
+  protected $blogCacheService;
+
+  public function __construct(BlogCacheService $blogCacheService) {
+    $this->blogCacheService = $blogCacheService;
+  }
+
+  /**
+   *
+   */
+  public static function getSubscribedEvents() {
+    return [
+      'entity.node.insert' => 'clearBlogCache',
+      'entity.node.update' => 'clearBlogCache',
+      'entity.node.delete' => 'clearBlogCache',
+    ];
+  }
+  
+
+  /**
+   * Clears the cache when a blog post is added or updated.
+   */
+  public function clearBlogCache($event) {
+    $node = $event->getNode();
+    if ($node->bundle() == 'blog') {
+      $this->blogCacheService->clearCache();
+    }
+  }
+
+}

--- a/drupal/web/modules/custom/omkar_cache_api/src/Service/BlogCacheService.php
+++ b/drupal/web/modules/custom/omkar_cache_api/src/Service/BlogCacheService.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Drupal\omkar_cache_api\Service;
+
+use Drupal\node\Entity\Node;
+use Drupal\Core\Cache\CacheBackendInterface;
+
+/**
+ * Service to cache and retrieve latest blog posts.
+ */
+class BlogCacheService {
+
+  protected $cacheBackend;
+
+  /**
+   * Constructor to inject the cache service.
+   */
+  public function __construct(CacheBackendInterface $cache_backend) {
+    $this->cacheBackend = $cache_backend;
+  }
+
+  /**
+   * Fetch latest blog posts from cache or database.
+   */
+  public function getLatestBlogs($limit = 5) {
+    $cid = 'omkar_cache_api:latest_blogs';
+    $cache = $this->cacheBackend->get($cid);
+
+    if ($cache) {
+      \Drupal::logger('omkar_cache_api')->notice('Cache HIT: Returning cached data.');
+      return $cache->data;
+    }
+    else {
+      \Drupal::logger('omkar_cache_api')->notice('Cache MISS: Fetching from database.');
+
+      // Fetch latest blogs from the database.
+      $query = \Drupal::entityQuery('node')
+        ->condition('status', 1)
+        ->condition('type', 'blog')
+        ->sort('created', 'DESC')
+        ->range(0, $limit)
+      // ✅ Explicit access check
+        ->accessCheck(TRUE);
+
+      $nids = $query->execute();
+      $nodes = Node::loadMultiple($nids);
+
+      $blogs = [];
+      foreach ($nodes as $node) {
+        $blogs[] = [
+          'title' => $node->getTitle(),
+          'url' => $node->toUrl()->toString(),
+        ];
+      }
+
+      // ✅ Cache data permanently
+      $this->cacheBackend->set($cid, $blogs, CacheBackendInterface::CACHE_PERMANENT, ['node_list']);
+
+      return $blogs;
+    }
+  }
+
+  /**
+   * Clears the cache when a blog post is updated.
+   */
+  public function clearCache() {
+    $this->cacheBackend->invalidate('omkar_cache_api:latest_blogs');
+  }
+
+}

--- a/drupal/web/modules/custom/omkar_state_api/omkar_state_api.module
+++ b/drupal/web/modules/custom/omkar_state_api/omkar_state_api.module
@@ -1,15 +1,21 @@
 <?php
 
-use Drupal\Core\State\StateInterface;
-use Drupal\Core\Messenger\MessengerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+/**
+ * @file
+ */
+
+use Drupal\omkar_state_api\Event\BlogPublishedEvent;
 
 /**
  * Implements hook_entity_insert().
  */
 function omkar_state_api_entity_insert($entity) {
   if ($entity->getEntityTypeId() === 'node' && $entity->bundle() === 'blog' && $entity->isPublished()) {
-    $state = \Drupal::state();
-    // $state->set('omkar_state_api.last_published_time', \Drupal::time()->getCurrentTime());
+    $dispatcher = \Drupal::service('event_dispatcher');
+
+    $event = new BlogPublishedEvent($entity);
+
+    $dispatcher->dispatch($event, BlogPublishedEvent::EVENT_NAME);
+
   }
 }


### PR DESCRIPTION
This PR introduces a custom Drupal module, omkar_cache_api, that caches and retrieves the latest blog posts to enhance performance. The module leverages Drupal's Cache API and automatically invalidates the cache when a blog post is created, updated, or deleted.

🚀 Features & Implementation
Caching Latest Blogs:

Fetches the latest 5 published blogs and caches them under the key omkar_cache_api:latest_blogs.

Avoids redundant database queries, improving site performance.

Cache Invalidation on Content Updates:

Uses an Event Subscriber (BlogEventSubscriber.php) to listen for entity.node.insert, entity.node.update, and entity.node.delete events.

Clears the cache when a blog post is added, updated, or deleted.

Dedicated Service for Caching:

BlogCacheService.php manages caching logic, ensuring separation of concerns.

Uses cache.default to store and retrieve cached blog data.

New Route for Displaying Latest Blogs:

/latest-blogs route displays cached blog posts.

Uses BlogController.php to retrieve cached data and render a list of blog links.

📂 Files Modified/Added
omkar_cache_api.info.yml - Defines the module and dependencies.

omkar_cache_api.services.yml - Registers caching service and event subscriber.

BlogController.php - Fetches cached blogs and renders them.

BlogCacheService.php - Implements caching logic.

BlogEventSubscriber.php - Listens for node events to clear cache.

omkar_cache_api.routing.yml - Defines /latest-blogs route.